### PR TITLE
Update SerializedDataConverter.php

### DIFF
--- a/app/code/Magento/Sales/Setup/SerializedDataConverter.php
+++ b/app/code/Magento/Sales/Setup/SerializedDataConverter.php
@@ -30,7 +30,7 @@ class SerializedDataConverter extends SerializedToJson
         $valueUnserialized = $this->unserializeValue($value);
         if (isset($valueUnserialized['options'])) {
             foreach ($valueUnserialized['options'] as $key => $option) {
-                if ($option['option_type'] === 'file') {
+                if (isset($option['option_type']) && $option['option_type'] === 'file') {
                     $valueUnserialized['options'][$key]['option_value'] = parent::convert($option['option_value']);
                 }
             }


### PR DESCRIPTION
this fix will check for migrated orders which don't have the requested `Option_type` index. will prevent `Notice: Undefined index: option_type in /usr/share/nginx/html/release/vendor/magento/module-sales/Setup/SerializedDataConverter.php on line 33  `

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
